### PR TITLE
add rtp_decoder to cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,12 @@ install(FILES include/srtp.h crypto/include/auth.h
 if(TEST_APPS)
   enable_testing()
 
+  find_package(PCAP)
+  if (PCAP_FOUND)
+    add_executable(rtp_decoder test/rtp_decoder.c test/getopt_s.c test/util.c)
+    target_link_libraries(rtp_decoder srtp2 ${PCAP_LIBRARY})
+  endif()
+
   if(NOT (BUILD_SHARED_LIBS AND WIN32))
     if(NOT USE_EXTERNAL_CRYPTO)
       add_executable(aes_calc crypto/test/aes_calc.c test/getopt_s.c test/util.c)

--- a/cmake/FindPCAP.cmake
+++ b/cmake/FindPCAP.cmake
@@ -1,0 +1,12 @@
+find_path(PCAP_INCLUDE_DIR_TEMP pcap.h)
+find_library(PCAP_LIBRARY_TEMP pcap)
+
+if (PCAP_INCLUDE_DIR_TEMP AND PCAP_LIBRARY_TEMP)
+  set(PCAP_LIBRARY pcap)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(PCAP DEFAULT_MSG
+    PCAP_LIBRARY)
+
+mark_as_advanced(PCAP_LIBRARY)

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1740,13 +1740,23 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t *ctx,
      * estimate the packet index using the start of the replay window
      * and the sequence number from the header
      */
-    delta = srtp_rdbx_estimate_index(&stream->rtp_rdbx, &est, ntohs(hdr->seq));
-    status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
-    if (status) {
-        if (status != srtp_err_status_replay_fail || !stream->allow_repeat_tx) {
-            return status; /* we've been asked to reuse an index */
-        }
+    status = srtp_get_est_pkt_index(hdr, stream, &est, &delta);
+
+    if (status && (status != srtp_err_status_pkt_idx_adv))
+        return status;
+
+    if (status == srtp_err_status_pkt_idx_adv) {
+        srtp_rdbx_set_roc_seq(&stream->rtp_rdbx, (uint32_t)(est >> 16),
+                              (uint16_t)(est & 0xFFFF));
+        stream->pending_roc = 0;
+        srtp_rdbx_add_index(&stream->rtp_rdbx, 0);
     } else {
+        status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
+        if (status) {
+            if (status != srtp_err_status_replay_fail ||
+                !stream->allow_repeat_tx)
+                return status; /* we've been asked to reuse an index */
+        }
         srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
     }
 
@@ -2064,7 +2074,6 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
     unsigned int mki_size = 0;
     srtp_session_keys_t *session_keys = NULL;
     uint8_t *mki_location = NULL;
-    int advance_packet_index = 0;
 
     debug_print0(mod_srtp, "function srtp_protect");
 
@@ -2215,10 +2224,7 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
     if (status && (status != srtp_err_status_pkt_idx_adv))
         return status;
 
-    if (status == srtp_err_status_pkt_idx_adv)
-        advance_packet_index = 1;
-
-    if (advance_packet_index) {
+    if (status == srtp_err_status_pkt_idx_adv) {
         srtp_rdbx_set_roc_seq(&stream->rtp_rdbx, (uint32_t)(est >> 16),
                               (uint16_t)(est & 0xFFFF));
         stream->pending_roc = 0;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -776,6 +776,25 @@ static inline int base_key_length(const srtp_cipher_type_t *cipher,
     }
 }
 
+/* Get the key length that the application should supply for the given cipher */
+static inline int full_key_length(const srtp_cipher_type_t *cipher) {
+  switch (cipher->id) {
+    case SRTP_NULL_CIPHER:
+    case SRTP_AES_ICM_128:
+        return SRTP_AES_ICM_128_KEY_LEN_WSALT;
+    case SRTP_AES_ICM_192:
+        return SRTP_AES_ICM_192_KEY_LEN_WSALT;
+    case SRTP_AES_ICM_256:
+        return SRTP_AES_ICM_256_KEY_LEN_WSALT;
+    case SRTP_AES_GCM_128:
+        return SRTP_AES_GCM_128_KEY_LEN_WSALT;
+    case SRTP_AES_GCM_256:
+        return SRTP_AES_ICM_256_KEY_LEN_WSALT;
+    default:
+        return 0;
+  }
+}
+
 unsigned int srtp_validate_policy_master_keys(const srtp_policy_t *policy)
 {
     unsigned long i = 0;
@@ -870,6 +889,7 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
     srtp_err_status_t stat;
     srtp_kdf_t kdf;
     uint8_t tmp_key[MAX_SRTP_KEY_LEN];
+    int input_keylen, input_keylen_rtcp;
     int kdf_keylen = 30, rtp_keylen, rtcp_keylen;
     int rtp_base_key_len, rtp_salt_len;
     int rtcp_base_key_len, rtcp_salt_len;
@@ -906,6 +926,12 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
 
     session_keys->mki_size = master_key->mki_size;
 
+    input_keylen = full_key_length(session_keys->rtp_cipher->type);
+    input_keylen_rtcp = full_key_length(session_keys->rtcp_cipher->type);
+    if (input_keylen_rtcp > input_keylen) {
+      input_keylen = input_keylen_rtcp;
+    }
+
     rtp_keylen = srtp_cipher_get_key_length(session_keys->rtp_cipher);
     rtcp_keylen = srtp_cipher_get_key_length(session_keys->rtcp_cipher);
     rtp_base_key_len =
@@ -920,6 +946,11 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
         kdf_keylen = 46; /* AES-CTR mode is always used for KDF */
     }
 
+    if (input_keylen > kdf_keylen) {
+        kdf_keylen = 46; /* AES-CTR mode is always used for KDF */
+    }
+
+    debug_print(mod_srtp, "input key len;: %d", input_keylen);
     debug_print(mod_srtp, "srtp key len: %d", rtp_keylen);
     debug_print(mod_srtp, "srtcp key len: %d", rtcp_keylen);
     debug_print(mod_srtp, "base key len: %d", rtp_base_key_len);
@@ -932,7 +963,7 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
      * the legacy CTR mode KDF, which uses a 112 bit master SALT.
      */
     memset(tmp_key, 0x0, MAX_SRTP_KEY_LEN);
-    memcpy(tmp_key, key, kdf_keylen);
+    memcpy(tmp_key, key, input_keylen);
 
 /* initialize KDF state     */
 #if defined(OPENSSL) && defined(OPENSSL_KDF)

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -932,7 +932,7 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
      * the legacy CTR mode KDF, which uses a 112 bit master SALT.
      */
     memset(tmp_key, 0x0, MAX_SRTP_KEY_LEN);
-    memcpy(tmp_key, key, (rtp_base_key_len + rtp_salt_len));
+    memcpy(tmp_key, key, kdf_keylen);
 
 /* initialize KDF state     */
 #if defined(OPENSSL) && defined(OPENSSL_KDF)

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -951,7 +951,7 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
         kdf_keylen = 46; /* AES-CTR mode is always used for KDF */
     }
 
-    debug_print(mod_srtp, "input key len;: %d", input_keylen);
+    debug_print(mod_srtp, "input key len: %d", input_keylen);
     debug_print(mod_srtp, "srtp key len: %d", rtp_keylen);
     debug_print(mod_srtp, "srtcp key len: %d", rtcp_keylen);
     debug_print(mod_srtp, "base key len: %d", rtp_base_key_len);

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -757,22 +757,20 @@ static inline int base_key_length(const srtp_cipher_type_t *cipher,
                                   int key_length)
 {
     switch (cipher->id) {
+    case SRTP_NULL_CIPHER:
+        return 0;
     case SRTP_AES_ICM_128:
     case SRTP_AES_ICM_192:
     case SRTP_AES_ICM_256:
         /* The legacy modes are derived from
          * the configured key length on the policy */
         return key_length - SRTP_SALT_LEN;
-        break;
     case SRTP_AES_GCM_128:
         return key_length - SRTP_AEAD_SALT_LEN;
-        break;
     case SRTP_AES_GCM_256:
         return key_length - SRTP_AEAD_SALT_LEN;
-        break;
     default:
         return key_length;
-        break;
     }
 }
 
@@ -3279,7 +3277,7 @@ void srtp_crypto_policy_set_null_cipher_hmac_sha1_80(srtp_crypto_policy_t *p)
      */
 
     p->cipher_type = SRTP_NULL_CIPHER;
-    p->cipher_key_len = 0;
+    p->cipher_key_len = 16;
     p->auth_type = SRTP_HMAC_SHA1;
     p->auth_key_len = 20;
     p->auth_tag_len = 10;
@@ -3293,7 +3291,7 @@ void srtp_crypto_policy_set_null_cipher_hmac_null(srtp_crypto_policy_t *p)
      */
 
     p->cipher_type = SRTP_NULL_CIPHER;
-    p->cipher_key_len = 0;
+    p->cipher_key_len = 16;
     p->auth_type = SRTP_NULL_AUTH;
     p->auth_key_len = 0;
     p->auth_tag_len = 0;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -777,8 +777,9 @@ static inline int base_key_length(const srtp_cipher_type_t *cipher,
 }
 
 /* Get the key length that the application should supply for the given cipher */
-static inline int full_key_length(const srtp_cipher_type_t *cipher) {
-  switch (cipher->id) {
+static inline int full_key_length(const srtp_cipher_type_t *cipher)
+{
+    switch (cipher->id) {
     case SRTP_NULL_CIPHER:
     case SRTP_AES_ICM_128:
         return SRTP_AES_ICM_128_KEY_LEN_WSALT;
@@ -792,7 +793,7 @@ static inline int full_key_length(const srtp_cipher_type_t *cipher) {
         return SRTP_AES_ICM_256_KEY_LEN_WSALT;
     default:
         return 0;
-  }
+    }
 }
 
 unsigned int srtp_validate_policy_master_keys(const srtp_policy_t *policy)
@@ -929,7 +930,7 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
     input_keylen = full_key_length(session_keys->rtp_cipher->type);
     input_keylen_rtcp = full_key_length(session_keys->rtcp_cipher->type);
     if (input_keylen_rtcp > input_keylen) {
-      input_keylen = input_keylen_rtcp;
+        input_keylen = input_keylen_rtcp;
     }
 
     rtp_keylen = srtp_cipher_get_key_length(session_keys->rtp_cipher);

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -177,6 +177,8 @@ int main(int argc, char *argv[])
     rtp_decoder_t dec;
     srtp_policy_t policy = { { 0 } };
     rtp_decoder_mode_t mode = mode_rtp;
+    srtp_ssrc_t ssrc = { ssrc_any_inbound, 0 };
+    uint32_t roc = 0;
     srtp_err_status_t status;
     int len;
     int expected_len;
@@ -202,7 +204,7 @@ int main(int argc, char *argv[])
 
     /* check args */
     while (1) {
-        c = getopt_s(argc, argv, "b:k:gt:ae:ld:f:c:m:p:o:");
+        c = getopt_s(argc, argv, "b:k:gt:ae:ld:f:c:m:p:o:s:r:");
         if (c == -1) {
             break;
         }
@@ -296,6 +298,13 @@ int main(int argc, char *argv[])
             break;
         case 'o':
             rtp_packet_offset = atoi(optarg_s);
+            break;
+        case 's':
+            ssrc.type = ssrc_specific;
+            ssrc.value = strtol(optarg_s, NULL, 0);
+            break;
+        case 'r':
+            roc = atoi(optarg_s);
             break;
         default:
             usage(argv[0]);
@@ -567,6 +576,13 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
+    policy.ssrc = ssrc;
+
+    if (roc != 0 && policy.ssrc.type != ssrc_specific) {
+        fprintf(stderr, "error: setting ROC (-r) requires -s <ssrc>\n");
+        exit(1);
+    }
+
     pcap_handle = pcap_open_offline(pcap_file, errbuf);
 
     if (!pcap_handle) {
@@ -590,7 +606,7 @@ int main(int argc, char *argv[])
         exit(1);
     }
     fprintf(stderr, "Starting decoder\n");
-    if (rtp_decoder_init(dec, policy, mode, rtp_packet_offset)) {
+    if (rtp_decoder_init(dec, policy, mode, rtp_packet_offset, roc)) {
         fprintf(stderr, "error: init failed\n");
         exit(1);
     }
@@ -623,7 +639,7 @@ void usage(char *string)
     fprintf(
         stderr,
         "usage: %s [-d <debug>]* [[-k][-b] <key>] [-a][-t][-e] [-c "
-        "<srtp-crypto-suite>] [-m <mode>]\n"
+        "<srtp-crypto-suite>] [-m <mode>] [-s <ssrc> [-r <roc>]]\n"
         "or     %s -l\n"
         "where  -a use message authentication\n"
         "       -e <key size> use encryption (use 128 or 256 for key size)\n"
@@ -638,7 +654,11 @@ void usage(char *string)
         "          on RFC4568-style crypto suite specification\n"
         "       -m <mode> set the mode to be one of [rtp]|rtcp|rtcp-mux\n"
         "       -p <pcap file> path to pcap file (defaults to stdin)\n"
-        "       -o byte offset of RTP packet in capture (defaults to 42)\n",
+        "       -o byte offset of RTP packet in capture (defaults to 42)\n"
+        "       -s <ssrc> restrict decrypting to the given SSRC (in host byte "
+        "order)\n"
+        "       -r <roc> initial rollover counter, requires -s <ssrc> "
+        "(defaults to 0)\n",
         string, string);
     exit(1);
 }
@@ -664,7 +684,8 @@ int rtp_decoder_deinit(rtp_decoder_t decoder)
 int rtp_decoder_init(rtp_decoder_t dcdr,
                      srtp_policy_t policy,
                      rtp_decoder_mode_t mode,
-                     int rtp_packet_offset)
+                     int rtp_packet_offset,
+                     uint32_t roc)
 {
     dcdr->rtp_offset = rtp_packet_offset;
     dcdr->srtp_ctx = NULL;
@@ -676,10 +697,15 @@ int rtp_decoder_init(rtp_decoder_t dcdr,
     dcdr->rtcp_cnt = 0;
     dcdr->mode = mode;
     dcdr->policy = policy;
-    dcdr->policy.ssrc.type = ssrc_any_inbound;
 
     if (srtp_create(&dcdr->srtp_ctx, &dcdr->policy)) {
         return 1;
+    }
+
+    if (policy.ssrc.type == ssrc_specific && roc != 0) {
+        if (srtp_set_stream_roc(dcdr->srtp_ctx, policy.ssrc.value, roc)) {
+            return 1;
+        }
     }
     return 0;
 }

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -202,7 +202,7 @@ int main(int argc, char *argv[])
 
     /* check args */
     while (1) {
-        c = getopt_s(argc, argv, "b:k:gt:ae:ld:f:s:m:p:o:");
+        c = getopt_s(argc, argv, "b:k:gt:ae:ld:f:c:m:p:o:");
         if (c == -1) {
             break;
         }
@@ -256,7 +256,7 @@ int main(int argc, char *argv[])
         case 'l':
             do_list_mods = 1;
             break;
-        case 's':
+        case 'c':
             for (i_scsp = &srtp_crypto_suites[0]; i_scsp->can_name != NULL;
                  i_scsp++) {
                 if (strcasecmp(i_scsp->can_name, optarg_s) == 0) {
@@ -622,7 +622,7 @@ void usage(char *string)
 {
     fprintf(
         stderr,
-        "usage: %s [-d <debug>]* [[-k][-b] <key>] [-a][-t][-e] [-s "
+        "usage: %s [-d <debug>]* [[-k][-b] <key>] [-a][-t][-e] [-c "
         "<srtp-crypto-suite>] [-m <mode>]\n"
         "or     %s -l\n"
         "where  -a use message authentication\n"
@@ -634,7 +634,7 @@ void usage(char *string)
         "       -l list debug modules\n"
         "       -f \"<pcap filter>\" to filter only the desired SRTP packets\n"
         "       -d <debug> turn on debugging for module <debug>\n"
-        "       -s \"<srtp-crypto-suite>\" to set both key and tag size based\n"
+        "       -c \"<srtp-crypto-suite>\" to set both key and tag size based\n"
         "          on RFC4568-style crypto suite specification\n"
         "       -m <mode> set the mode to be one of [rtp]|rtcp|rtcp-mux\n"
         "       -p <pcap file> path to pcap file (defaults to stdin)\n"

--- a/test/rtp_decoder.h
+++ b/test/rtp_decoder.h
@@ -102,7 +102,8 @@ void rtp_decoder_dealloc(rtp_decoder_t rtp_ctx);
 int rtp_decoder_init(rtp_decoder_t dcdr,
                      srtp_policy_t policy,
                      rtp_decoder_mode_t mode,
-                     int rtp_packet_offset);
+                     int rtp_packet_offset,
+                     uint32_t roc);
 
 int rtp_decoder_deinit(rtp_decoder_t decoder);
 

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -61,6 +61,8 @@
 
 srtp_err_status_t srtp_validate(void);
 
+srtp_err_status_t srtp_validate_null(void);
+
 #ifdef GCM
 srtp_err_status_t srtp_validate_gcm(void);
 #endif
@@ -436,6 +438,15 @@ int main(int argc, char *argv[])
         printf("testing srtp_protect and srtp_unprotect against "
                "reference packet\n");
         if (srtp_validate() == srtp_err_status_ok) {
+            printf("passed\n\n");
+        } else {
+            printf("failed\n");
+            exit(1);
+        }
+
+        printf("testing srtp_protect and srtp_unprotect against "
+               "reference packet using null cipher and HMAC\n");
+        if (srtp_validate_null() == srtp_err_status_ok) {
             printf("passed\n\n");
         } else {
             printf("failed\n");
@@ -1709,6 +1720,166 @@ srtp_err_status_t srtp_validate()
     memset(&policy, 0, sizeof(policy));
     srtp_crypto_policy_set_rtp_default(&policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&policy.rtcp);
+    policy.ssrc.type = ssrc_specific;
+    policy.ssrc.value = 0xcafebabe;
+    policy.key = test_key;
+    policy.deprecated_ekt = NULL;
+    policy.window_size = 128;
+    policy.allow_repeat_tx = 0;
+    policy.next = NULL;
+
+    status = srtp_create(&srtp_snd, &policy);
+    if (status) {
+        return status;
+    }
+
+    /*
+     * protect plaintext, then compare with ciphertext
+     */
+    len = 28;
+    status = srtp_protect(srtp_snd, srtp_plaintext, &len);
+    if (status || (len != 38)) {
+        return srtp_err_status_fail;
+    }
+
+    debug_print(mod_driver, "ciphertext:\n  %s",
+                octet_string_hex_string(srtp_plaintext, len));
+    debug_print(mod_driver, "ciphertext reference:\n  %s",
+                octet_string_hex_string(srtp_ciphertext, len));
+
+    if (srtp_octet_string_is_eq(srtp_plaintext, srtp_ciphertext, len)) {
+        return srtp_err_status_fail;
+    }
+
+    /*
+     * protect plaintext rtcp, then compare with srtcp ciphertext
+     */
+    len = 24;
+    status = srtp_protect_rtcp(srtp_snd, rtcp_plaintext, &len);
+    if (status || (len != 38)) {
+        return srtp_err_status_fail;
+    }
+
+    debug_print(mod_driver, "srtcp ciphertext:\n  %s",
+                octet_string_hex_string(rtcp_plaintext, len));
+    debug_print(mod_driver, "srtcp ciphertext reference:\n  %s",
+                octet_string_hex_string(srtcp_ciphertext, len));
+
+    if (srtp_octet_string_is_eq(rtcp_plaintext, srtcp_ciphertext, len)) {
+        return srtp_err_status_fail;
+    }
+
+    /*
+     * create a receiver session context comparable to the one created
+     * above - we need to do this so that the replay checking doesn't
+     * complain
+     */
+    status = srtp_create(&srtp_recv, &policy);
+    if (status) {
+        return status;
+    }
+
+    /*
+     * unprotect ciphertext, then compare with plaintext
+     */
+    status = srtp_unprotect(srtp_recv, srtp_ciphertext, &len);
+    if (status || (len != 28)) {
+        return status;
+    }
+
+    if (srtp_octet_string_is_eq(srtp_ciphertext, srtp_plaintext_ref, len)) {
+        return srtp_err_status_fail;
+    }
+
+    /*
+     * unprotect srtcp ciphertext, then compare with rtcp plaintext
+     */
+    len = 38;
+    status = srtp_unprotect_rtcp(srtp_recv, srtcp_ciphertext, &len);
+    if (status || (len != 24)) {
+        return status;
+    }
+
+    if (srtp_octet_string_is_eq(srtcp_ciphertext, rtcp_plaintext_ref, len)) {
+        return srtp_err_status_fail;
+    }
+
+    status = srtp_dealloc(srtp_snd);
+    if (status) {
+        return status;
+    }
+
+    status = srtp_dealloc(srtp_recv);
+    if (status) {
+        return status;
+    }
+
+    return srtp_err_status_ok;
+}
+
+/*
+ * srtp_validate_null() verifies the correctness of libsrtp by comparing
+ * some computed packets against some pre-computed reference values.
+ * These packets were made with a policy that applies null encryption
+ * and HMAC authentication.
+ */
+
+srtp_err_status_t srtp_validate_null()
+{
+    // clang-format off
+    uint8_t srtp_plaintext_ref[28] = {
+        0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
+        0xca, 0xfe, 0xba, 0xbe, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab
+    };
+    uint8_t srtp_plaintext[38] = {
+        0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
+        0xca, 0xfe, 0xba, 0xbe, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+    uint8_t srtp_ciphertext[38] = {
+        0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
+        0xca, 0xfe, 0xba, 0xbe, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xa1, 0x36, 0x27,
+        0x0b, 0x67, 0x91, 0x34, 0xce, 0x9b
+    };
+    uint8_t rtcp_plaintext_ref[24] = {
+        0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+    };
+    uint8_t rtcp_plaintext[38] = {
+        0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    };
+    uint8_t srtcp_ciphertext[38] = {
+        0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0x00, 0x00, 0x00, 0x01, 0xfe, 0x88, 0xc7, 0xfd,
+        0xfd, 0x37, 0xeb, 0xce, 0x61, 0x5d,
+    };
+    // clang-format on
+
+    srtp_t srtp_snd, srtp_recv;
+    srtp_err_status_t status;
+    int len;
+    srtp_policy_t policy;
+
+    /*
+     * create a session with a single stream using the default srtp
+     * policy and with the SSRC value 0xcafebabe
+     */
+    memset(&policy, 0, sizeof(policy));
+    srtp_crypto_policy_set_null_cipher_hmac_sha1_80(&policy.rtp);
+    srtp_crypto_policy_set_null_cipher_hmac_sha1_80(&policy.rtcp);
     policy.ssrc.type = ssrc_specific;
     policy.ssrc.value = 0xcafebabe;
     policy.key = test_key;

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -3091,11 +3091,17 @@ static srtp_err_status_t test_set_receiver_roc(uint32_t packets,
 
     /* Create sender */
     memset(&sender_policy, 0, sizeof(sender_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtcp);
+    sender_policy.key = test_key_gcm;
+#else
     srtp_crypto_policy_set_rtp_default(&sender_policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&sender_policy.rtcp);
+    sender_policy.key = test_key;
+#endif
     sender_policy.ssrc.type = ssrc_specific;
     sender_policy.ssrc.value = 0xcafebabe;
-    sender_policy.key = test_key;
     sender_policy.window_size = 128;
 
     status = srtp_create(&sender_session, &sender_policy);
@@ -3144,11 +3150,17 @@ static srtp_err_status_t test_set_receiver_roc(uint32_t packets,
 
     /* Create the receiver */
     memset(&receiver_policy, 0, sizeof(receiver_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtcp);
+    receiver_policy.key = test_key_gcm;
+#else
     srtp_crypto_policy_set_rtp_default(&receiver_policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&receiver_policy.rtcp);
+    receiver_policy.key = test_key;
+#endif
     receiver_policy.ssrc.type = ssrc_specific;
     receiver_policy.ssrc.value = sender_policy.ssrc.value;
-    receiver_policy.key = test_key;
     receiver_policy.window_size = 128;
 
     status = srtp_create(&receiver_session, &receiver_policy);
@@ -3230,11 +3242,17 @@ static srtp_err_status_t test_set_sender_roc(uint16_t seq, uint32_t roc_to_set)
 
     /* Create sender */
     memset(&sender_policy, 0, sizeof(sender_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtcp);
+    sender_policy.key = test_key_gcm;
+#else
     srtp_crypto_policy_set_rtp_default(&sender_policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&sender_policy.rtcp);
+    sender_policy.key = test_key;
+#endif
     sender_policy.ssrc.type = ssrc_specific;
     sender_policy.ssrc.value = 0xcafebabe;
-    sender_policy.key = test_key;
     sender_policy.window_size = 128;
 
     status = srtp_create(&sender_session, &sender_policy);
@@ -3261,11 +3279,17 @@ static srtp_err_status_t test_set_sender_roc(uint16_t seq, uint32_t roc_to_set)
 
     /* Create the receiver */
     memset(&receiver_policy, 0, sizeof(receiver_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtcp);
+    receiver_policy.key = test_key_gcm;
+#else
     srtp_crypto_policy_set_rtp_default(&receiver_policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&receiver_policy.rtcp);
+    receiver_policy.key = test_key;
+#endif
     receiver_policy.ssrc.type = ssrc_specific;
     receiver_policy.ssrc.value = sender_policy.ssrc.value;
-    receiver_policy.key = test_key;
     receiver_policy.window_size = 128;
 
     status = srtp_create(&receiver_session, &receiver_policy);

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -95,6 +95,8 @@ srtp_err_status_t srtp_test_get_roc(void);
 
 srtp_err_status_t srtp_test_set_receiver_roc(void);
 
+srtp_err_status_t srtp_test_set_receiver_roc_then_rollover(void);
+
 srtp_err_status_t srtp_test_set_sender_roc(void);
 
 double srtp_bits_per_second(int msg_len_octets, const srtp_policy_t *policy);
@@ -126,6 +128,7 @@ extern uint8_t test_key[46];
 extern uint8_t test_key_2[46];
 extern uint8_t test_mki_id[TEST_MKI_ID_SIZE];
 extern uint8_t test_mki_id_2[TEST_MKI_ID_SIZE];
+extern uint8_t test_key_gcm[28];
 
 // clang-format off
 srtp_master_key_t master_key_1 = {
@@ -558,6 +561,14 @@ int main(int argc, char *argv[])
 
         printf("testing srtp_test_set_receiver_roc()...");
         if (srtp_test_set_receiver_roc() == srtp_err_status_ok) {
+            printf("passed\n");
+        } else {
+            printf("failed\n");
+            exit(1);
+        }
+
+        printf("testing srtp_test_set_receiver_roc_then_rollover()...");
+        if (srtp_test_set_receiver_roc_then_rollover() == srtp_err_status_ok) {
             printf("passed\n");
         } else {
             printf("failed\n");
@@ -1803,12 +1814,6 @@ srtp_err_status_t srtp_validate()
 srtp_err_status_t srtp_validate_gcm()
 {
     // clang-format off
-    unsigned char test_key_gcm[28] = {
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
-        0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
-        0xa8, 0xa9, 0xaa, 0xab
-    };
     uint8_t rtp_plaintext_ref[28] = {
         0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
         0xca, 0xfe, 0xba, 0xbe, 0xab, 0xab, 0xab, 0xab,
@@ -3364,6 +3369,183 @@ srtp_err_status_t srtp_test_set_receiver_roc()
     return srtp_err_status_ok;
 }
 
+srtp_err_status_t srtp_test_set_receiver_roc_then_rollover()
+{
+    srtp_err_status_t status;
+
+    srtp_policy_t sender_policy;
+    srtp_t sender_session;
+
+    srtp_policy_t receiver_policy;
+    srtp_t receiver_session;
+
+    srtp_hdr_t *pkt_1;
+    unsigned char *recv_pkt_1;
+
+    srtp_hdr_t *pkt_2;
+    unsigned char *recv_pkt_2;
+
+    uint32_t i;
+    uint32_t ts;
+    uint16_t seq;
+    uint32_t sender_roc;
+
+    int msg_len_octets = 32;
+    int protected_msg_len_octets_1;
+    int protected_msg_len_octets_2;
+
+    /* Create sender */
+    memset(&sender_policy, 0, sizeof(sender_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtcp);
+    sender_policy.key = test_key_gcm;
+#else
+    srtp_crypto_policy_set_rtp_default(&sender_policy.rtp);
+    srtp_crypto_policy_set_rtcp_default(&sender_policy.rtcp);
+    sender_policy.key = test_key;
+#endif
+    sender_policy.ssrc.type = ssrc_specific;
+    sender_policy.ssrc.value = 0xcafebabe;
+    sender_policy.window_size = 128;
+
+    status = srtp_create(&sender_session, &sender_policy);
+    if (status) {
+        return status;
+    }
+
+    /* Create and protect packets to get to seq 65536 and roc == 1 */
+    seq = 65535;
+    ts = 0;
+    for (i = 0; i < 65535; i++) {
+        srtp_hdr_t *tmp_pkt;
+        int tmp_len;
+
+        tmp_pkt = srtp_create_test_packet_extended(
+            msg_len_octets, sender_policy.ssrc.value, seq, ts, &tmp_len);
+        status = srtp_protect(sender_session, tmp_pkt, &tmp_len);
+        free(tmp_pkt);
+        if (status) {
+            return status;
+        }
+
+        seq++;
+        ts++;
+    }
+
+    status = srtp_get_stream_roc(sender_session, sender_policy.ssrc.value,
+                                 &sender_roc);
+    if (status) {
+        return status;
+    }
+
+    if (sender_roc != 1) {
+        return srtp_err_status_fail;
+    }
+
+    /* Create the first packet to decrypt and test for ROC change */
+    pkt_1 = srtp_create_test_packet_extended(msg_len_octets,
+                                             sender_policy.ssrc.value, 65535,
+                                             ts, &protected_msg_len_octets_1);
+    status = srtp_protect(sender_session, pkt_1, &protected_msg_len_octets_1);
+    if (status) {
+        return status;
+    }
+
+    /* Create the second packet to decrypt and test for ROC change */
+    ts++;
+    pkt_2 = srtp_create_test_packet_extended(msg_len_octets,
+                                             sender_policy.ssrc.value, 0, ts,
+                                             &protected_msg_len_octets_2);
+    status = srtp_protect(sender_session, pkt_2, &protected_msg_len_octets_2);
+    if (status) {
+        return status;
+    }
+
+    status = srtp_get_stream_roc(sender_session, sender_policy.ssrc.value,
+                                 &sender_roc);
+    if (status) {
+        return status;
+    }
+
+    if (sender_roc != 2) {
+        return srtp_err_status_fail;
+    }
+
+    /* Create the receiver */
+    memset(&receiver_policy, 0, sizeof(receiver_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtcp);
+    receiver_policy.key = test_key_gcm;
+#else
+    srtp_crypto_policy_set_rtp_default(&receiver_policy.rtp);
+    srtp_crypto_policy_set_rtcp_default(&receiver_policy.rtcp);
+    receiver_policy.key = test_key;
+#endif
+    receiver_policy.ssrc.type = ssrc_specific;
+    receiver_policy.ssrc.value = sender_policy.ssrc.value;
+    receiver_policy.window_size = 128;
+
+    status = srtp_create(&receiver_session, &receiver_policy);
+    if (status) {
+        return status;
+    }
+
+    /* Make a copy of the first sent protected packet */
+    recv_pkt_1 = malloc(protected_msg_len_octets_1);
+    if (recv_pkt_1 == NULL) {
+        return srtp_err_status_fail;
+    }
+    memcpy(recv_pkt_1, pkt_1, protected_msg_len_octets_1);
+
+    /* Make a copy of the second sent protected packet */
+    recv_pkt_2 = malloc(protected_msg_len_octets_2);
+    if (recv_pkt_2 == NULL) {
+        return srtp_err_status_fail;
+    }
+    memcpy(recv_pkt_2, pkt_2, protected_msg_len_octets_2);
+
+    /* Set the ROC to the wanted value */
+    status =
+        srtp_set_stream_roc(receiver_session, receiver_policy.ssrc.value, 1);
+    if (status) {
+        return status;
+    }
+
+    /* Unprotect the first packet */
+    status = srtp_unprotect(receiver_session, recv_pkt_1,
+                            &protected_msg_len_octets_1);
+    if (status) {
+        return status;
+    }
+
+    /* Unprotect the second packet */
+    status = srtp_unprotect(receiver_session, recv_pkt_2,
+                            &protected_msg_len_octets_2);
+    if (status) {
+        return status;
+    }
+
+    /* Cleanup */
+    status = srtp_dealloc(sender_session);
+    if (status) {
+        return status;
+    }
+
+    status = srtp_dealloc(receiver_session);
+    if (status) {
+        return status;
+    }
+
+    free(pkt_1);
+    free(recv_pkt_1);
+    free(pkt_2);
+    free(recv_pkt_2);
+
+    return srtp_err_status_ok;
+}
+
 srtp_err_status_t srtp_test_set_sender_roc()
 {
     uint32_t roc;
@@ -3425,6 +3607,13 @@ unsigned char test_key_2[46] = {
     0xe6, 0x22, 0xa0, 0xe3, 0x32, 0xb9, 0xf1, 0xb6,
     0xc3, 0x17, 0xf2, 0xda, 0xbe, 0x35, 0x77, 0x93,
     0xb6, 0x96, 0x0b, 0x3a, 0xab, 0xe6
+};
+
+unsigned char test_key_gcm[28] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+    0xa8, 0xa9, 0xaa, 0xab
 };
 
 unsigned char test_mki_id[TEST_MKI_ID_SIZE] = {


### PR DESCRIPTION
This will build as part of test apps.
A very simple find PCAP package is supported. This should be
sufficient as it is a seldom used test tool. It can be expanded
as needed.