### PR TITLE
Treat warnings as errors when building with cmake

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,18 +12,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        crypto: [internal, openssl, nss, mbedtls]
+        crypto: [internal, openssl, openssl3, nss, mbedtls]
         exclude:
           - os: windows-latest
             crypto: openssl
           - os: windows-latest
+            crypto: openssl3
+          - os: windows-latest
             crypto: nss
           - os: windows-latest
             crypto: mbedtls
+          - os: ubuntu-latest
+            crypto: openssl3
         include:
           - crypto: internal
             cmake-crypto-enable: ""
           - crypto: openssl
+            cmake-crypto-enable: "-DENABLE_OPENSSL=ON"
+          - crypto: openssl3
             cmake-crypto-enable: "-DENABLE_OPENSSL=ON"
           - crypto: nss
             cmake-crypto-enable: "-DENABLE_NSS=ON"
@@ -31,7 +37,7 @@ jobs:
             cmake-crypto-enable: "-DENABLE_MBEDTLS=ON"
 
     runs-on: ${{ matrix.os }}
-    
+
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
 
@@ -41,23 +47,29 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libnss3-dev
-      
+
     - name: Setup Ubuntu MbedTLS
       if:  matrix.os == 'ubuntu-latest' && matrix.crypto == 'mbedtls'
       run: sudo apt-get install libmbedtls-dev
-    
+
     - name: Setup macOS OpenSSL
       if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl'
       run: echo "cmake-crypto-dir=-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
-      
+
+    - name: Setup macOS OpenSSL3
+      if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl3'
+      run: |
+        brew install openssl@3
+        echo "cmake-crypto-dir=-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
+
     - name: Setup macOS NSS
       if:  matrix.os == 'macos-latest' && matrix.crypto == 'nss'
       run: brew install nss
-      
+
     - name: Setup macOS MbedTLS
       if:  matrix.os == 'macos-latest' && matrix.crypto == 'mbedtls'
       run: brew install mbedtls
-      
+
     - uses: actions/checkout@v2
 
     - name: Create Build Environment

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,10 @@ if(BUILD_WITH_SANITIZERS AND NOT WIN32)
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=${SANITIZERS}")
 endif()
 
+if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
+  add_compile_options(-Werror)
+endif()
+
 set(SOURCES_C
   srtp/srtp.c
 )

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -51,7 +51,14 @@
 #include "err.h" /* for srtp_debug */
 #include "auth_test_cases.h"
 #include <openssl/evp.h>
+
+#if defined(OPENSSL_VERSION_MAJOR) && (OPENSSL_VERSION_MAJOR >= 3)
+#define SRTP_OSSL_USE_EVP_MAC
+#endif
+
+#ifndef SRTP_OSSL_USE_EVP_MAC
 #include <openssl/hmac.h>
+#endif
 
 #define SHA1_DIGEST_SIZE 20
 
@@ -62,11 +69,21 @@ srtp_debug_module_t srtp_mod_hmac = {
     "hmac sha-1 openssl" /* printable name for module   */
 };
 
+typedef struct {
+#ifdef SRTP_OSSL_USE_EVP_MAC
+    EVP_MAC *mac;
+    EVP_MAC_CTX *ctx;
+#else
+    HMAC_CTX *ctx;
+#endif
+} srtp_hmac_ossl_ctx_t;
+
 static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
                                          int key_len,
                                          int out_len)
 {
     extern const srtp_auth_type_t srtp_hmac;
+    srtp_hmac_ossl_ctx_t *hmac;
 
     debug_print(srtp_mod_hmac, "allocating auth func with key length %d",
                 key_len);
@@ -83,14 +100,39 @@ static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
         return srtp_err_status_alloc_fail;
     }
 
-    (*a)->state = HMAC_CTX_new();
-    if ((*a)->state == NULL) {
+    hmac =
+        (srtp_hmac_ossl_ctx_t *)srtp_crypto_alloc(sizeof(srtp_hmac_ossl_ctx_t));
+    if (hmac == NULL) {
+        srtp_crypto_free(*a);
+        *a = NULL;
+        return srtp_err_status_alloc_fail;
+    }
+
+#ifdef SRTP_OSSL_USE_EVP_MAC
+    hmac->mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+    if (hmac->mac == NULL) {
+        srtp_crypto_free(hmac);
+        srtp_crypto_free(*a);
+        *a = NULL;
+        return srtp_err_status_alloc_fail;
+    }
+
+    hmac->ctx = EVP_MAC_CTX_new(hmac->mac);
+#else
+    hmac->ctx = HMAC_CTX_new();
+#endif
+    if (hmac->ctx == NULL) {
+#ifdef SRTP_OSSL_USE_EVP_MAC
+        EVP_MAC_free(hmac->mac);
+#endif
+        srtp_crypto_free(hmac);
         srtp_crypto_free(*a);
         *a = NULL;
         return srtp_err_status_alloc_fail;
     }
 
     /* set pointers */
+    (*a)->state = hmac;
     (*a)->type = &srtp_hmac;
     (*a)->out_len = out_len;
     (*a)->key_len = key_len;
@@ -101,11 +143,20 @@ static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
 
 static srtp_err_status_t srtp_hmac_dealloc(srtp_auth_t *a)
 {
-    HMAC_CTX *hmac_ctx;
+    srtp_hmac_ossl_ctx_t *hmac = (srtp_hmac_ossl_ctx_t *)a->state;
 
-    hmac_ctx = (HMAC_CTX *)a->state;
+    if (hmac) {
+#ifdef SRTP_OSSL_USE_EVP_MAC
+        EVP_MAC_CTX_free(hmac->ctx);
+        EVP_MAC_free(hmac->mac);
+#else
+        HMAC_CTX_free(hmac->ctx);
+#endif
+        /* zeroize entire state*/
+        octet_string_set_to_zero(hmac, sizeof(srtp_hmac_ossl_ctx_t));
 
-    HMAC_CTX_free(hmac_ctx);
+        srtp_crypto_free(hmac);
+    }
 
     /* zeroize entire state*/
     octet_string_set_to_zero(a, sizeof(srtp_auth_t));
@@ -118,11 +169,15 @@ static srtp_err_status_t srtp_hmac_dealloc(srtp_auth_t *a)
 
 static srtp_err_status_t srtp_hmac_start(void *statev)
 {
-    HMAC_CTX *state = (HMAC_CTX *)statev;
+    srtp_hmac_ossl_ctx_t *hmac = (srtp_hmac_ossl_ctx_t *)statev;
 
-    if (HMAC_Init_ex(state, NULL, 0, NULL, NULL) == 0)
+#ifdef SRTP_OSSL_USE_EVP_MAC
+    if (EVP_MAC_init(hmac->ctx, NULL, 0, NULL) == 0)
         return srtp_err_status_auth_fail;
-
+#else
+    if (HMAC_Init_ex(hmac->ctx, NULL, 0, NULL, NULL) == 0)
+        return srtp_err_status_auth_fail;
+#endif
     return srtp_err_status_ok;
 }
 
@@ -130,11 +185,20 @@ static srtp_err_status_t srtp_hmac_init(void *statev,
                                         const uint8_t *key,
                                         int key_len)
 {
-    HMAC_CTX *state = (HMAC_CTX *)statev;
+    srtp_hmac_ossl_ctx_t *hmac = (srtp_hmac_ossl_ctx_t *)statev;
 
-    if (HMAC_Init_ex(state, key, key_len, EVP_sha1(), NULL) == 0)
+#ifdef SRTP_OSSL_USE_EVP_MAC
+    OSSL_PARAM params[2];
+
+    params[0] = OSSL_PARAM_construct_utf8_string("digest", "SHA1", 0);
+    params[1] = OSSL_PARAM_construct_end();
+
+    if (EVP_MAC_init(hmac->ctx, key, key_len, params) == 0)
         return srtp_err_status_auth_fail;
-
+#else
+    if (HMAC_Init_ex(hmac->ctx, key, key_len, EVP_sha1(), NULL) == 0)
+        return srtp_err_status_auth_fail;
+#endif
     return srtp_err_status_ok;
 }
 
@@ -142,14 +206,18 @@ static srtp_err_status_t srtp_hmac_update(void *statev,
                                           const uint8_t *message,
                                           int msg_octets)
 {
-    HMAC_CTX *state = (HMAC_CTX *)statev;
+    srtp_hmac_ossl_ctx_t *hmac = (srtp_hmac_ossl_ctx_t *)statev;
 
     debug_print(srtp_mod_hmac, "input: %s",
                 srtp_octet_string_hex_string(message, msg_octets));
 
-    if (HMAC_Update(state, message, msg_octets) == 0)
+#ifdef SRTP_OSSL_USE_EVP_MAC
+    if (EVP_MAC_update(hmac->ctx, message, msg_octets) == 0)
         return srtp_err_status_auth_fail;
-
+#else
+    if (HMAC_Update(hmac->ctx, message, msg_octets) == 0)
+        return srtp_err_status_auth_fail;
+#endif
     return srtp_err_status_ok;
 }
 
@@ -159,10 +227,14 @@ static srtp_err_status_t srtp_hmac_compute(void *statev,
                                            int tag_len,
                                            uint8_t *result)
 {
-    HMAC_CTX *state = (HMAC_CTX *)statev;
+    srtp_hmac_ossl_ctx_t *hmac = (srtp_hmac_ossl_ctx_t *)statev;
     uint8_t hash_value[SHA1_DIGEST_SIZE];
     int i;
+#ifdef SRTP_OSSL_USE_EVP_MAC
+    size_t len;
+#else
     unsigned int len;
+#endif
 
     debug_print(srtp_mod_hmac, "input: %s",
                 srtp_octet_string_hex_string(message, msg_octets));
@@ -173,12 +245,19 @@ static srtp_err_status_t srtp_hmac_compute(void *statev,
     }
 
     /* hash message, copy output into H */
-    if (HMAC_Update(state, message, msg_octets) == 0)
+#ifdef SRTP_OSSL_USE_EVP_MAC
+    if (EVP_MAC_update(hmac->ctx, message, msg_octets) == 0)
         return srtp_err_status_auth_fail;
 
-    if (HMAC_Final(state, hash_value, &len) == 0)
+    if (EVP_MAC_final(hmac->ctx, hash_value, &len, sizeof hash_value) == 0)
+        return srtp_err_status_auth_fail;
+#else
+    if (HMAC_Update(hmac->ctx, message, msg_octets) == 0)
         return srtp_err_status_auth_fail;
 
+    if (HMAC_Final(hmac->ctx, hash_value, &len) == 0)
+        return srtp_err_status_auth_fail;
+#endif
     if (len < tag_len)
         return srtp_err_status_auth_fail;
 


### PR DESCRIPTION
This will catch OpenSSL deprecated api warnings.