### PR TITLE
T warn err 1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,9 @@ if(BUILD_WITH_SANITIZERS AND NOT WIN32)
 endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
-  add_compile_options(-Werror)
+  add_compile_options(-Wall -pedantic -Wextra -Werror)
+elseif(MSVC)
+  add_compile_options(/W4 /WX)
 endif()
 
 set(SOURCES_C

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,10 @@ if(BUILD_WITH_SANITIZERS AND NOT WIN32)
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=${SANITIZERS}")
 endif()
 
+if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
+  add_compile_options(-Werror)
+endif()
+
 set(SOURCES_C
   srtp/srtp.c
 )

--- a/crypto/cipher/aes_gcm_mbedtls.c
+++ b/crypto/cipher/aes_gcm_mbedtls.c
@@ -256,7 +256,6 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_set_aad(void *cv,
                                                       uint32_t aad_len)
 {
     FUNC_ENTRY();
-    int errCode = 0;
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
 
     debug_print(srtp_mod_aes_gcm, "setting AAD: %s",
@@ -343,7 +342,6 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_decrypt(void *cv,
     FUNC_ENTRY();
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     int errCode = 0;
-    int len = *enc_len;
 
     if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
         return (srtp_err_status_bad_param);

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -280,7 +280,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_aad(void *cv,
     }
 
     rv = EVP_Cipher(c->ctx, NULL, aad, aad_len);
-    if (rv != aad_len) {
+    if (rv < 0 || (uint32_t)rv != aad_len) {
         return (srtp_err_status_algo_fail);
     } else {
         return (srtp_err_status_ok);

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -98,6 +98,7 @@ static srtp_err_status_t srtp_aes_icm_alloc(srtp_cipher_t **c,
                                             int tlen)
 {
     srtp_aes_icm_ctx_t *icm;
+    (void)tlen;
 
     debug_print(srtp_mod_aes_icm, "allocating cipher with key length %d",
                 key_len);
@@ -238,6 +239,7 @@ static srtp_err_status_t srtp_aes_icm_set_iv(void *cv,
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     v128_t nonce;
+    (void)direction;
 
     /* set nonce (for alignment) */
     v128_copy_octet_string(&nonce, iv);

--- a/crypto/cipher/aes_icm_mbedtls.c
+++ b/crypto/cipher/aes_icm_mbedtls.c
@@ -118,6 +118,7 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_alloc(srtp_cipher_t **c,
                                                     int tlen)
 {
     srtp_aes_icm_ctx_t *icm;
+    (void)tlen;
 
     debug_print(srtp_mod_aes_icm, "allocating cipher with key length %d",
                 key_len);
@@ -264,6 +265,8 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_set_iv(
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     v128_t nonce;
+    (void)dir;
+
     c->nc_off = 0;
     /* set nonce (for alignment) */
     v128_copy_octet_string(&nonce, iv);

--- a/crypto/cipher/aes_icm_nss.c
+++ b/crypto/cipher/aes_icm_nss.c
@@ -107,6 +107,7 @@ static srtp_err_status_t srtp_aes_icm_nss_alloc(srtp_cipher_t **c,
 {
     srtp_aes_icm_ctx_t *icm;
     NSSInitContext *nss;
+    (void)tlen;
 
     debug_print(srtp_mod_aes_icm, "allocating cipher with key length %d",
                 key_len);
@@ -275,6 +276,7 @@ static srtp_err_status_t srtp_aes_icm_nss_set_iv(void *cv,
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     v128_t nonce;
+    (void)dir;
 
     /* set nonce (for alignment) */
     v128_copy_octet_string(&nonce, iv);

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -112,6 +112,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_alloc(srtp_cipher_t **c,
                                                     int tlen)
 {
     srtp_aes_icm_ctx_t *icm;
+    (void)tlen;
 
     debug_print(srtp_mod_aes_icm, "allocating cipher with key length %d",
                 key_len);
@@ -275,6 +276,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_set_iv(
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     v128_t nonce;
+    (void)dir;
 
     /* set nonce (for alignment) */
     v128_copy_octet_string(&nonce, iv);

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -59,6 +59,7 @@ static srtp_err_status_t srtp_null_cipher_alloc(srtp_cipher_t **c,
                                                 int tlen)
 {
     extern const srtp_cipher_type_t srtp_null_cipher;
+    (void)tlen;
 
     debug_print(srtp_mod_cipher, "allocating cipher with key length %d",
                 key_len);
@@ -96,7 +97,8 @@ static srtp_err_status_t srtp_null_cipher_dealloc(srtp_cipher_t *c)
 static srtp_err_status_t srtp_null_cipher_init(void *cv, const uint8_t *key)
 {
     /* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */
-
+    (void)cv;
+    (void)key;
     debug_print0(srtp_mod_cipher, "initializing null cipher");
 
     return srtp_err_status_ok;
@@ -107,6 +109,9 @@ static srtp_err_status_t srtp_null_cipher_set_iv(void *cv,
                                                  srtp_cipher_direction_t dir)
 {
     /* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */
+    (void)cv;
+    (void)iv;
+    (void)dir;
     return srtp_err_status_ok;
 }
 
@@ -115,6 +120,9 @@ static srtp_err_status_t srtp_null_cipher_encrypt(void *cv,
                                                   unsigned int *bytes_to_encr)
 {
     /* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */
+    (void)cv;
+    (void)buf;
+    (void)bytes_to_encr;
     return srtp_err_status_ok;
 }
 

--- a/crypto/hash/hmac_nss.c
+++ b/crypto/hash/hmac_nss.c
@@ -256,7 +256,7 @@ static srtp_err_status_t srtp_hmac_compute(void *statev,
         return srtp_err_status_auth_fail;
     }
 
-    if (len < tag_len)
+    if (tag_len < 0 || len < (unsigned int)tag_len)
         return srtp_err_status_auth_fail;
 
     /* copy hash_value to *result */

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -179,7 +179,7 @@ static srtp_err_status_t srtp_hmac_compute(void *statev,
     if (HMAC_Final(state, hash_value, &len) == 0)
         return srtp_err_status_auth_fail;
 
-    if (len < tag_len)
+    if (tag_len < 0 || len < (unsigned int)tag_len)
         return srtp_err_status_auth_fail;
 
     /* copy hash_value to *result */

--- a/crypto/hash/null_auth.c
+++ b/crypto/hash/null_auth.c
@@ -102,6 +102,10 @@ static srtp_err_status_t srtp_null_auth_init(void *statev,
                                              int key_len)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
+    (void)statev;
+    (void)key;
+    (void)key_len;
+
     /* accept any length of key, and do nothing */
 
     return srtp_err_status_ok;
@@ -114,6 +118,11 @@ static srtp_err_status_t srtp_null_auth_compute(void *statev,
                                                 uint8_t *result)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
+    (void)statev;
+    (void)message;
+    (void)msg_octets;
+    (void)tag_len;
+    (void)result;
 
     return srtp_err_status_ok;
 }
@@ -123,6 +132,9 @@ static srtp_err_status_t srtp_null_auth_update(void *statev,
                                                int msg_octets)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
+    (void)statev;
+    (void)message;
+    (void)msg_octets;
 
     return srtp_err_status_ok;
 }
@@ -130,6 +142,7 @@ static srtp_err_status_t srtp_null_auth_update(void *statev,
 static srtp_err_status_t srtp_null_auth_start(void *statev)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
+    (void)statev;
 
     return srtp_err_status_ok;
 }

--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -166,6 +166,11 @@ void octet_string_set_to_zero(void *s, size_t len);
 #include <byteswap.h>
 #define be32_to_cpu(x) bswap_32((x))
 #define be64_to_cpu(x) bswap_64((x))
+#elif defined(__APPLE__)
+// Mac OS X / Darwin features
+#include <libkern/OSByteOrder.h>
+#define be32_to_cpu(x) OSSwapInt32(x)
+#define be64_to_cpu(x) OSSwapInt64(x)
 #else /* WORDS_BIGENDIAN */
 
 #if defined(__GNUC__) && (defined(HAVE_X86) || defined(__x86_64__))

--- a/crypto/replay/rdbx.c
+++ b/crypto/replay/rdbx.c
@@ -279,7 +279,7 @@ srtp_err_status_t srtp_rdbx_add_index(srtp_rdbx_t *rdbx, int delta)
 {
     if (delta > 0) {
         /* shift forward by delta */
-        srtp_index_advance(&rdbx->index, delta);
+        srtp_index_advance(&rdbx->index, (srtp_sequence_number_t)delta);
         bitvector_left_shift(&rdbx->bitmask, delta);
         bitvector_set_bit(&rdbx->bitmask,
                           bitvector_get_length(&rdbx->bitmask) - 1);

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -389,7 +389,7 @@ srtp_err_status_t cipher_driver_test_buffering(srtp_cipher_t *c)
 
             /* make sure that len doesn't cause us to overreach the buffer */
             if (current + len > end)
-                len = end - current;
+                len = (unsigned)(end - current);
 
             status = srtp_cipher_encrypt(c, current, &len);
             if (status)

--- a/crypto/test/datatypes_driver.c
+++ b/crypto/test/datatypes_driver.c
@@ -139,12 +139,12 @@ int main(void)
 
 void byte_order(void)
 {
-    int i;
+    size_t i;
     v128_t e;
 
     printf("byte ordering of crypto/math datatypes:\n");
     for (i = 0; i < sizeof(e); i++)
-        e.v8[i] = i;
+        e.v8[i] = (uint8_t)i;
     printf("v128_t: %s\n", v128_hex_string(&e));
 }
 
@@ -155,12 +155,12 @@ void test_hex_string_funcs(void)
     char raw[10];
     int len;
 
-    len = hex_string_to_octet_string(raw, hex1, strlen(hex1));
+    len = hex_string_to_octet_string(raw, hex1, (int)strlen(hex1));
     printf("computed length: %d\tstring: %s\n", len,
            octet_string_hex_string(raw, len / 2));
     printf("expected length: %u\tstring: %s\n", (unsigned)strlen(hex1), hex1);
 
-    len = hex_string_to_octet_string(raw, hex2, strlen(hex2));
+    len = hex_string_to_octet_string(raw, hex2, (int)strlen(hex2));
     printf("computed length: %d\tstring: %s\n", len,
            octet_string_hex_string(raw, len / 2));
     printf("expected length: %d\tstring: %s\n", 16, "0123456789abcdef");

--- a/crypto/test/sha1_driver.c
+++ b/crypto/test/sha1_driver.c
@@ -143,7 +143,7 @@ srtp_err_status_t sha1_test_case_validate(const hash_test_case_t *test_case)
 struct hex_sha1_test_case_t {
     unsigned bit_len;
     char hex_data[MAX_HASH_DATA_LEN * 2];
-    char hex_hash[40];
+    char hex_hash[40 + 1];
 };
 
 srtp_err_status_t sha1_add_test_cases(void)

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1845,7 +1845,7 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t *ctx,
     /*
      * Set the AAD over the RTP header
      */
-    aad_len = (uint8_t *)enc_start - (uint8_t *)hdr;
+    aad_len = (uint32_t)((uint8_t *)enc_start - (uint8_t *)hdr);
     status =
         srtp_cipher_set_aad(session_keys->rtp_cipher, (uint8_t *)hdr, aad_len);
     if (status) {
@@ -1991,7 +1991,7 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t *ctx,
     /*
      * Set the AAD for AES-GCM, which is the RTP header
      */
-    aad_len = (uint8_t *)enc_start - (uint8_t *)hdr;
+    aad_len = (uint32_t)((uint8_t *)enc_start - (uint8_t *)hdr);
     status =
         srtp_cipher_set_aad(session_keys->rtp_cipher, (uint8_t *)hdr, aad_len);
     if (status) {
@@ -3552,7 +3552,6 @@ static srtp_err_status_t srtp_calc_aead_iv_srtcp(
  * AES-GCM mode with 128 or 256 bit keys.
  */
 static srtp_err_status_t srtp_protect_rtcp_aead(
-    srtp_t ctx,
     srtp_stream_ctx_t *stream,
     void *rtcp_hdr,
     unsigned int *pkt_octet_len,
@@ -4004,7 +4003,7 @@ srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
      */
     if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
         session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
-        return srtp_protect_rtcp_aead(ctx, stream, rtcp_hdr,
+        return srtp_protect_rtcp_aead(stream, rtcp_hdr,
                                       (unsigned int *)pkt_octet_len,
                                       session_keys, use_mki);
     }

--- a/test/rdbx_driver.c
+++ b/test/rdbx_driver.c
@@ -143,7 +143,7 @@ srtp_err_status_t rdbx_check_add(srtp_rdbx_t *rdbx, uint32_t idx)
     int delta;
     srtp_xtd_seq_num_t est;
 
-    delta = srtp_index_guess(&rdbx->index, &est, idx);
+    delta = srtp_index_guess(&rdbx->index, &est, (srtp_sequence_number_t)idx);
 
     if (srtp_rdbx_check(rdbx, delta) != srtp_err_status_ok) {
         printf("replay_check failed at index %u\n", idx);
@@ -176,7 +176,7 @@ srtp_err_status_t rdbx_check_expect_failure(srtp_rdbx_t *rdbx, uint32_t idx)
     srtp_xtd_seq_num_t est;
     srtp_err_status_t status;
 
-    delta = srtp_index_guess(&rdbx->index, &est, idx);
+    delta = srtp_index_guess(&rdbx->index, &est, (srtp_sequence_number_t)idx);
 
     status = srtp_rdbx_check(rdbx, delta);
     if (status == srtp_err_status_ok) {
@@ -194,7 +194,7 @@ srtp_err_status_t rdbx_check_add_unordered(srtp_rdbx_t *rdbx, uint32_t idx)
     srtp_xtd_seq_num_t est;
     srtp_err_status_t rstat;
 
-    delta = srtp_index_guess(&rdbx->index, &est, idx);
+    delta = srtp_index_guess(&rdbx->index, &est, (srtp_sequence_number_t)idx);
 
     rstat = srtp_rdbx_check(rdbx, delta);
     if ((rstat != srtp_err_status_ok) &&
@@ -333,7 +333,7 @@ double rdbx_check_adds_per_second(int num_trials, unsigned long ws)
     failures = 0;
     timer = clock();
     for (i = 0; (int)i < num_trials; i++) {
-        delta = srtp_index_guess(&rdbx.index, &est, i);
+        delta = srtp_index_guess(&rdbx.index, &est, (srtp_sequence_number_t)i);
 
         if (srtp_rdbx_check(&rdbx, delta) != srtp_err_status_ok)
             ++failures;

--- a/test/roc_driver.c
+++ b/test/roc_driver.c
@@ -145,7 +145,7 @@ srtp_err_status_t roc_test(int num_trials)
 
         /* now update local srtp_xtd_seq_num_t as necessary */
         if (delta > 0)
-            srtp_index_advance(&local, delta);
+            srtp_index_advance(&local, (srtp_sequence_number_t)delta);
 
         if (ref != est) {
 #if ROC_VERBOSE

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -135,6 +135,7 @@ void rtp_decoder_srtp_log_handler(srtp_log_level_t level,
                                   const char *msg,
                                   void *data)
 {
+    (void)data;
     char level_char = '?';
     switch (level) {
     case srtp_log_level_error:
@@ -173,9 +174,9 @@ int main(int argc, char *argv[])
     struct bpf_program fp;
     char filter_exp[MAX_FILTER] = "";
     char pcap_file[MAX_FILE] = "-";
-    int rtp_packet_offset = DEFAULT_RTP_OFFSET;
+    size_t rtp_packet_offset = DEFAULT_RTP_OFFSET;
     rtp_decoder_t dec;
-    srtp_policy_t policy = { { 0 } };
+    srtp_policy_t policy = { 0 };
     rtp_decoder_mode_t mode = mode_rtp;
     srtp_ssrc_t ssrc = { ssrc_any_inbound, 0 };
     uint32_t roc = 0;
@@ -555,7 +556,7 @@ int main(int argc, char *argv[])
                     expected_len, len);
             exit(1);
         }
-        if (strlen(input_key) > policy.rtp.cipher_key_len * 2) {
+        if (strlen(input_key) > (size_t)policy.rtp.cipher_key_len * 2) {
             fprintf(stderr,
                     "error: too many digits in key/salt "
                     "(should be %d hexadecimal digits, found %u)\n",
@@ -684,7 +685,7 @@ int rtp_decoder_deinit(rtp_decoder_t decoder)
 int rtp_decoder_init(rtp_decoder_t dcdr,
                      srtp_policy_t policy,
                      rtp_decoder_mode_t mode,
-                     int rtp_packet_offset,
+                     size_t rtp_packet_offset,
                      uint32_t roc)
 {
     dcdr->rtp_offset = rtp_packet_offset;
@@ -716,11 +717,11 @@ int rtp_decoder_init(rtp_decoder_t dcdr,
 
 void hexdump(const void *ptr, size_t size)
 {
-    int i, j;
+    size_t i, j;
     const unsigned char *cptr = ptr;
 
     for (i = 0; i < size; i += 16) {
-        fprintf(stdout, "%04x ", i);
+        fprintf(stdout, "%04x ", (unsigned int)i);
         for (j = 0; j < 16 && i + j < size; j++) {
             fprintf(stdout, "%02x ", cptr[i + j]);
         }

--- a/test/rtp_decoder.h
+++ b/test/rtp_decoder.h
@@ -62,7 +62,7 @@ typedef struct rtp_decoder_ctx_t {
     srtp_policy_t policy;
     srtp_ctx_t *srtp_ctx;
     rtp_decoder_mode_t mode;
-    int rtp_offset;
+    size_t rtp_offset;
     struct timeval start_tv;
     int frame_nr;
     int error_cnt;
@@ -102,7 +102,7 @@ void rtp_decoder_dealloc(rtp_decoder_t rtp_ctx);
 int rtp_decoder_init(rtp_decoder_t dcdr,
                      srtp_policy_t policy,
                      rtp_decoder_mode_t mode,
-                     int rtp_packet_offset,
+                     size_t rtp_packet_offset,
                      uint32_t roc);
 
 int rtp_decoder_deinit(rtp_decoder_t decoder);

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -220,7 +220,7 @@ int main(int argc, char *argv[])
     unsigned do_list_mods = 0;
     unsigned do_log_stdout = 0;
     srtp_err_status_t status;
-    size_t hdr_size = 12;
+    const size_t hdr_size = 12;
 
     /*
      * verify that the compiler has interpreted the header data
@@ -228,8 +228,8 @@ int main(int argc, char *argv[])
      */
     if (sizeof(srtp_hdr_t) != hdr_size) {
         printf("error: srtp_hdr_t has incorrect size"
-               "(size is %ld bytes, expected 12)\n",
-               (long)sizeof(srtp_hdr_t));
+               "(size is %ld bytes, expected %ld)\n",
+               (long)sizeof(srtp_hdr_t), (long)hdr_size);
         exit(1);
     }
 

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -168,6 +168,7 @@ void usage(char *prog_name)
 void log_handler(srtp_log_level_t level, const char *msg, void *data)
 {
     char level_char = '?';
+    (void)data;
     switch (level) {
     case srtp_log_level_error:
         level_char = 'e';
@@ -219,12 +220,13 @@ int main(int argc, char *argv[])
     unsigned do_list_mods = 0;
     unsigned do_log_stdout = 0;
     srtp_err_status_t status;
+    size_t hdr_size = 12;
 
     /*
      * verify that the compiler has interpreted the header data
      * structure srtp_hdr_t correctly
      */
-    if (sizeof(srtp_hdr_t) != 12) {
+    if (sizeof(srtp_hdr_t) != hdr_size) {
         printf("error: srtp_hdr_t has incorrect size"
                "(size is %ld bytes, expected 12)\n",
                (long)sizeof(srtp_hdr_t));
@@ -2986,6 +2988,9 @@ srtp_err_status_t srtp_test_setup_protect_trailer_streams(
 #ifdef GCM
     srtp_policy_t policy_aes_gcm;
     srtp_policy_t policy_aes_gcm_mki;
+#else
+    (void)srtp_send_aes_gcm;
+    (void)srtp_send_aes_gcm_mki;
 #endif // GCM
 
     memset(&policy, 0, sizeof(policy));
@@ -3181,7 +3186,7 @@ srtp_err_status_t srtp_test_out_of_order_after_rollover()
     srtp_policy_t receiver_policy;
     srtp_t receiver_session;
 
-    const int num_pkts = 5;
+    const uint32_t num_pkts = 5;
     srtp_hdr_t *pkts[5];
     int pkt_len_octets[5];
 

--- a/test/test_srtp.c
+++ b/test/test_srtp.c
@@ -78,7 +78,7 @@ TEST_LIST = { { "srtp_calc_aead_iv_srtcp_all_zero_input_yield_zero_output()",
                 srtp_calc_aead_iv_srtcp_seq_num_over_0x7FFFFFFF_bad_param },
               { "srtp_calc_aead_iv_srtcp_distinct_iv_per_sequence_number()",
                 srtp_calc_aead_iv_srtcp_distinct_iv_per_sequence_number },
-              { NULL } /* End of tests */ };
+              { 0 } /* End of tests */ };
 
 /*
  * Implementation.
@@ -94,8 +94,7 @@ void srtp_calc_aead_iv_srtcp_all_zero_input_yield_zero_output()
 
     // Postconditions
     srtp_err_status_t status;
-    const v128_t zero_vector;
-    memset((v128_t *)&zero_vector, 0, sizeof(v128_t));
+    const v128_t zero_vector = { 0 };
 
     // Given
     memset(&session_keys, 0, sizeof(srtp_session_keys_t));

--- a/test/ut_sim.c
+++ b/test/ut_sim.c
@@ -54,6 +54,8 @@
 int ut_compar(const void *a, const void *b)
 {
     uint8_t r;
+    (void)a;
+    (void)b;
     srtp_cipher_rand_for_tests(&r, sizeof(r));
     return r > (UINT8_MAX / 2) ? -1 : 1;
 }

--- a/test/util.c
+++ b/test/util.c
@@ -101,8 +101,6 @@ static inline int hex_char_to_nibble(uint8_t c)
     default:
         return -1; /* this flags an error */
     }
-    /* NOTREACHED */
-    return -1; /* this keeps compilers from complaining */
 }
 
 uint8_t nibble_to_hex_char(uint8_t nibble)
@@ -129,7 +127,7 @@ int hex_string_to_octet_string(char *raw, char *hex, int len)
         if (tmp == -1) {
             return hex_len;
         }
-        x = (tmp << 4);
+        x = (uint8_t)(tmp << 4);
         hex_len++;
         tmp = hex_char_to_nibble(hex[1]);
         if (tmp == -1) {
@@ -176,7 +174,7 @@ static int base64_block_to_octet_triple(char *out, char *in)
     for (i = 0; i < 4; i++) {
         char *p = strchr(b64chars, in[i]);
         if (p != NULL) {
-            sextets[i] = p - b64chars;
+            sextets[i] = (unsigned char)(p - b64chars);
         } else {
             j++;
         }


### PR DESCRIPTION
This makes the cmake CI build stricter by add more warnings and forcing them all to be fixed.
For now warnings as errors enabled by default with cmake, could be optional in the future.

Follow up from change first introduced in #602 